### PR TITLE
Remove organization from main nav.

### DIFF
--- a/ckanext/iaea/templates/header.html
+++ b/ckanext/iaea/templates/header.html
@@ -1,0 +1,10 @@
+{% ckan_extends %}
+
+{% block header_site_navigation %}
+      <nav class="section navigation">
+        <ul class="nav nav-pills">
+          {% block header_site_navigation_tabs %} {{ h.build_nav_main( ('search', _('Datasets')),
+          ('group_index', _('Groups')), ('home.about', _('About')) ) }} {% endblock %}
+        </ul>
+      </nav>
+{% endblock %}


### PR DESCRIPTION
**fixes for : #2** 
- Header template extended in order to remove organization options from the main navigation. 
