### PR TITLE
Replace footer link with IEAE address

### DIFF
--- a/ckanext/iaea/templates/footer.html
+++ b/ckanext/iaea/templates/footer.html
@@ -1,0 +1,16 @@
+{% ckan_extends %}
+
+{% block footer_nav %}
+  <div class="row">
+    <div class="col-sm-6">
+      <h4>International Atomic Energy Agency</h4>
+      <p>Vienna International Centre, PO Box 100
+        <br>A-1400 Vienna, Austria
+        <br>Telephone: +43 (1) 2600-0, Facsimile +43 (1) 2600-7</p>
+      <p>
+        <i class="fa fa-fw fa-envelope"></i>
+        <a href="https://www.iaea.org/contact/official-mail">Official Email</a>
+      </p>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
**Fixes for #7** 

**Changes:** 
-  added address on the footer. (**Note:** currently contact link will redirect users to  https://www.iaea.org/contact/official-mail ) 

**Screenshot after implementation** 

<img width="1430" alt="Screen Shot 2021-05-18 at 7 25 19 PM" src="https://user-images.githubusercontent.com/11631101/118661408-d0f98b00-b80e-11eb-9c4c-7d031491e487.png">

