### PR TITLE
 contact dataset owner link button added on dataset page

### DIFF
--- a/ckanext/iaea/templates/package/read.html
+++ b/ckanext/iaea/templates/package/read.html
@@ -8,10 +8,10 @@
   {% if pkg.state == 'deleted' %}
           [{{ _('Deleted') }}]
   {% endif %}
-  {% if pkg.author_email %}
-    <a  href="mailto:{{pkg.author_email}}" class="btn btn-default" style="float: right;">
+  {% if pkg.maintainer_email %}
+    <a  href="mailto:{{pkg.maintainer_email}}" class="btn btn-default" style="float: right;">
       <i class="fa fa-envelope"></i> 
-        Contact dataset owner
+        Contact dataset maintainer
     </a>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
**Fixes  for :** #23 

Note:  The email address is configurable from package metadata `author email`


**Screeshot:** 
<img width="1262" alt="Screen Shot 2021-06-01 at 7 11 46 AM" src="https://user-images.githubusercontent.com/11631101/120254063-b01e4480-c2a8-11eb-8f4a-2acdf05f343f.png">
