### PR TITLE
[xs]: catch filter fields keyerror

### DIFF
--- a/ckanext/iaea/plugin.py
+++ b/ckanext/iaea/plugin.py
@@ -19,7 +19,10 @@ def featured_group():
 
 def suggested_filter_fields_serializer(datapackage, view_dict):
     suggested_filter_fields = view_dict.get('suggested_filter_fields', False)
-    fields = datapackage['resources'][0]['schema']['fields']
+    try:
+        fields = datapackage['resources'][0]['schema']['fields']
+    except KeyError as e:
+        fields = []
     rules = []
     date  = {}
     if suggested_filter_fields: 


### PR DESCRIPTION
In some cases, this line:
```python
fields = datapackage['resources'][0]['schema']['fields']
```
is called when the resource has not been pushed to datastore correctly, and that causes an internal server error for the user.
If that happens, this fix catches the error and sets the `fields` variable to an empty array.