### PR TITLE
Improvement on view feature on dataset page

### DIFF
--- a/ckanext/iaea/fanstatic/css/main-rtl.css
+++ b/ckanext/iaea/fanstatic/css/main-rtl.css
@@ -15608,6 +15608,19 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
   display: inline;
   margin-right: 5px;
 }
+.dataset-view-container {
+  display: flex;
+  align-content: center;
+  justify-content: space-between;
+  align-items: center;
+  position: relative;
+}
+.dataset-view-container .action {
+  margin-top: 20px;
+  position: absolute;
+  right: 0;
+  top: 69px;
+}
 .dataset-feature-view {
   width: 100%;
   height: 550px;

--- a/ckanext/iaea/fanstatic/css/main.css
+++ b/ckanext/iaea/fanstatic/css/main.css
@@ -8690,6 +8690,19 @@ fieldset[disabled] .control-custom.disabled .checkbox.btn.focus {
   display: inline;
   margin-right: 5px;
 }
+.dataset-view-container {
+  display: flex;
+  align-content: center;
+  justify-content: space-between;
+  align-items: center;
+  position: relative;
+}
+.dataset-view-container .action {
+  margin-top: 20px;
+  position: absolute;
+  right: 0;
+  top: 69px;
+}
 .dataset-feature-view {
   width: 100%;
   height: 550px;

--- a/ckanext/iaea/public/base/less/dataset.less
+++ b/ckanext/iaea/public/base/less/dataset.less
@@ -473,7 +473,21 @@
     }
 }
 
+.dataset-view-container {
+    display: flex;
+    align-content: center;
+    justify-content: space-between;
+    align-items: center;
+    position: relative;
+    .action {
+        margin-top: 20px;
+        position: absolute;
+        right: 0;
+        top: 69px;
+    }
+}
+
 .dataset-feature-view {
     width: 100%;
-    height: 550px;
+    height: 550px;  
 }

--- a/ckanext/iaea/templates/package/features_view.html
+++ b/ckanext/iaea/templates/package/features_view.html
@@ -2,8 +2,10 @@
 
 {% block primary_content_inner %}
 {% if package_views %}
+
 <form action="#" method="post">
     <fieldset class="fields-feature-view form-group">
+        <p>Select a view that should be featured on the dataset page.</p>
         {% for resource in package_views %}
         <h3> {{ resource.resource_name }}</h3>
         {% for view in resource.views %}

--- a/ckanext/iaea/templates/package/read_base.html
+++ b/ckanext/iaea/templates/package/read_base.html
@@ -20,7 +20,9 @@
 {% block content_primary_nav %}
   {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
   {{ h.build_nav_icon('iaea.metadata', _('Metadata'), id=pkg.name, icon='fa fa-tag') }}
-  {{ h.build_nav_icon('iaea.feature_view', _('View'), id=pkg.name, icon='check-square-o') }}
+  {% if h.check_access('package_update', {'id':pkg.id }) %}
+    {{ h.build_nav_icon('iaea.feature_view', _('View'), id=pkg.name, icon='check-square-o') }}
+  {% endif %}
 {% endblock %}
 
 {% block primary_content_inner %}
@@ -108,6 +110,15 @@
   </div>
 </div>
   {% if pkg.featured_view %}
+    <div class="dataset-view-container">
+      <h2>Featured Visualization</h2>
+      <div class="action">
+        <a class="btn btn-default" target="_blank" href="{{h.featured_view_url(pkg)}}">
+          <i class="fa fa-arrows-alt"></i>
+          Fullscreen
+        </a>
+      </div>
+    </div>
     <iframe src="{{h.featured_view_url(pkg)}}" class="dataset-feature-view"></iframe>
   {% endif %}
 {% endblock %}

--- a/ckanext/iaea/view.py
+++ b/ckanext/iaea/view.py
@@ -122,13 +122,17 @@ class FeatureView(MethodView):
         package_views_dict = []
         package_views_list = sorted(package_views_list, key=lambda k: k['resource_id'])
         for k, v in groupby(package_views_list, key=lambda x: x['resource_id']):
-            resource_name = model.Session.query(model.Resource.name).filter(
-                model.Resource.id == k).first()[0]
-            view_dict = {
-                'resource_name': resource_name,
-                'resource_id': k,
-                'views': list(v)
-            }
+            [resource_name, state ] = model.Session.query(model.Resource.name.label('name'), model.Resource.state.label('state')).filter(
+                model.Resource.id == k).first()
+
+            if state == 'deleted':
+                continue 
+            else: 
+                view_dict = {
+                    'resource_name': resource_name,
+                    'resource_id': k,
+                    'views': list(v)
+                }
 
             package_views_dict.append(view_dict)
 
@@ -166,13 +170,17 @@ class FeatureView(MethodView):
         package_views_dict = []
         package_views_list = sorted(package_views_list, key=lambda k: k['resource_id'])
         for k, v in groupby(package_views_list, key=lambda x: x['resource_id']):
-            resource_name = model.Session.query(model.Resource.name).filter(
-                model.Resource.id == k).first()[0]
-            view_dict = {
-                'resource_name': resource_name,
-                'resource_id': k,
-                'views': list(v)
-            }
+            [resource_name, state ] = model.Session.query(model.Resource.name.label('name'), model.Resource.state.label('state')).filter(
+                model.Resource.id == k).first()
+
+            if state == 'deleted':
+                continue 
+            else: 
+                view_dict = {
+                    'resource_name': resource_name,
+                    'resource_id': k,
+                    'views': list(v)
+                }
 
             package_views_dict.append(view_dict)
 


### PR DESCRIPTION
-  [Bug fixed] Deleted views were also displaying. 
-  [Bug Fixed] Do not show the `views` tab if the user doesn’t have access to edit. 
- Title `Featured Visualization` and message added on edit UI `Select a view that should be featured on the dataset page`.
- Full screen button added.
<img width="1322" alt="Screen Shot 2022-05-27 at 12 03 35 PM" src="https://user-images.githubusercontent.com/87696933/170642114-bc9c95e0-3baf-4547-9aff-5541eaf75a55.png">
<img width="947" alt="Screen Shot 2022-05-27 at 12 04 07 PM" src="https://user-images.githubusercontent.com/87696933/170642177-e52a3b61-1f5f-4aed-b23f-71eb9b14c13d.png">